### PR TITLE
 Number of 1 Bits

### DIFF
--- a/Number of 1 Bits
+++ b/Number of 1 Bits
@@ -1,0 +1,14 @@
+public class Solution {
+    // you need to treat n as an unsigned value
+    public int hammingWeight(int n) {
+        int count = 0;
+        long nn = Integer.toUnsignedLong(n);
+        System.out.println(nn);
+        while(nn > 0){
+            nn = nn - (nn & (-nn));
+            count++;
+        }
+        
+        return count;
+    }
+}


### PR DESCRIPTION
Write a function that takes an unsigned integer and returns the number of '1' bits it has (also known as the Hamming weight).

Note:

Note that in some languages, such as Java, there is no unsigned integer type. In this case, the input will be given as a signed integer type. It should not affect your implementation, as the integer's internal binary representation is the same, whether it is signed or unsigned. In Java, the compiler represents the signed integers using 2's complement notation. Therefore, in Example 3, the input represents the signed integer. -3.